### PR TITLE
Improve landing page accessibility and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,17 +34,17 @@
     <meta name="twitter:site" content="@SakuraTKOficial">    
 </head>
 <body>
-
+    <a class="skip-link" href="#features">本文へスキップ</a>
 
     <main>
         <section id="top">
             <div>
                 <h1>さくら<wbr>雑談王国</h1>
                 <p>1000人超えの大規模Discord雑談コミュニティ</p>
-                <button class="join_button">さくら雑談王国に参加する</button>
+                <button class="join_button" type="button">さくら雑談王国に参加する</button>
             </div>
-            <a href="#features">
-                <img src="./assets/icons/scroll.webp" alt="スクロールアイコン">
+            <a class="scroll-link" href="#features" aria-label="さくら雑談王国のいいところへスクロール">
+                <img src="./assets/icons/scroll.webp" alt="" aria-hidden="true">
             </a>
         </section>
 
@@ -77,30 +77,30 @@
                     </p>
                 </li>
             </ul>
-            <button class="join_button">参加する</button>
+            <button class="join_button" type="button">参加する</button>
         </section>
 
         <section id="news">
             <h2>お知らせ</h2>
-            <div id="news_box">
-                <h3>お知らせを取得しています。。。</h3>
+            <div id="news_box" aria-live="polite" aria-busy="true">
+                <p class="loading-message">お知らせを取得しています...</p>
             </div>
         </section>
 
         <section id="server-info">
             <h2>現在の<wbr>サーバー状況</h2>
-            <div id="api-data-area">
+            <div id="api-data-area" aria-live="polite">
                 <p>現在のメンバー数: <span id="member-count">取得中...</span>人</p>
                 <p>現在のオンライン数: <span id="online-count">取得中...</span>人</p>
-                <p>現在のVC: <span id="vc-count">取得中...</span>人</p>
+                <p>現在のVC参加数: <span id="vc-count">取得中...</span>人</p>
                 <small id="server_info_timestamp">※ botの状況により取得できない場合があります。</small>
             </div>
         </section>
 
         <section id="events">
             <h2>現在のイベント</h2>
-            <div id="events-api">
-
+            <div id="events-api" aria-live="polite">
+                <p class="loading-message">イベントを取得しています...</p>
             </div>
         </section>
         
@@ -117,12 +117,12 @@
                             さくら雑談王国独自のbot。認証などを請け負います。<br>
                             開発者は副鯖主のわたあめえさんです。
                         </p>
-                        <a href="https://kiyaku.bot.sakurahp.f5.si/teams/">規約</a>
-                        <a href="https://kiyaku.bot.sakurahp.f5.si/privacy/">プライバシーポリシー</a>
+                        <a href="https://kiyaku.bot.sakurahp.f5.si/teams/" rel="noopener">規約</a>
+                        <a href="https://kiyaku.bot.sakurahp.f5.si/privacy/" rel="noopener">プライバシーポリシー</a>
                     </li>
-                    <li id="bots_others" style="grid-row: 1 / 2; grid-column: 2 / 3;">
+                    <li id="bots_others">
                         <h3>その他bot</h3>
-                        <p>現在取得しています。。。</p>
+                        <p>現在取得しています...</p>
                     </li>
                 </ul>
             </div>
@@ -130,9 +130,8 @@
 
         <section id="rules">
             <h2>サーバールール</h2>
+            <p class="section-lead">皆が安心して利用するための基本的なルールです。詳細はサーバー内でご確認ください。</p>
             <ul>
-                <p>皆が安心して利用するための基本的なルールです。詳細はサーバー内でご確認ください。</p>
-
                 <li>
                     <h3>1. 荒らし行為・ハッキング行為・過度なメンションの禁止</h3>
                     <p>
@@ -198,7 +197,7 @@
                     </p>
                 </li>
             </ul>
-            <button class="join_button">参加する</button>
+            <button class="join_button" type="button">参加する</button>
         </section>
 
         <section id="admin">
@@ -339,15 +338,15 @@
         <section id="contact">
             <h2>お問い合わせ</h2>
             <form action="https://sites-backends.onrender.com/contacts" method="post">
-            <p>ご意見やご質問はこちらからお願いいたします。</p>
-                <label for="name">名前
-                <input type="text" id="name" name="name" required></label>
+                <p>ご意見やご質問はこちらからお願いいたします。</p>
+                <label for="name">名前 <span aria-hidden="true">*</span></label>
+                <input type="text" id="name" name="name" autocomplete="name" required aria-required="true">
                 
-                <label for="email">メールアドレス(任意)
-                <input type="email" id="email" name="email"></label>
+                <label for="email">メールアドレス(任意)</label>
+                <input type="email" id="email" name="email" autocomplete="email">
 
-                <label for="message">メッセージ
-                <textarea id="message" name="message" required></textarea></label>
+                <label for="message">メッセージ <span aria-hidden="true">*</span></label>
+                <textarea id="message" name="message" required aria-required="true"></textarea>
                 
                 <button type="submit">送信</button>
             </form>
@@ -355,13 +354,13 @@
         </section>
 
         <section class="join-button-footer">
-            <button class="join_button">参加する</button>
+            <button class="join_button" type="button">参加する</button>
         </section>
 
     </main>
 
     <footer>
-        <p>&copy; <a href="https://imme.kotoca.net">Imme(架流さん)</a> All Rights Reserved.</p>
+        <p>&copy; <a href="https://imme.kotoca.net" rel="noopener">Imme(架流さん)</a> All Rights Reserved.</p>
         <p>このサイトはImmeによって作成・運営されています。お仕事のご依頼はリンク先まで。</p>
     </footer>
     <script src="./others/script.js" defer></script>

--- a/others/script.js
+++ b/others/script.js
@@ -3,10 +3,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     const allowedGuildId = "1208962938388484107";
     const buttons = document.querySelectorAll(".join_button");
 
-    // --- ページロード時に invite 検証 ---
-    
-// ... initInvite 関数の定義を以下のように修正 ...
-
     async function initInvite() {
         const params = new URLSearchParams(window.location.search);
         const rawCode = params.get("invite");
@@ -17,111 +13,117 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
 
         try {
-            console.log(`[検証開始] Code: ${rawCode} をAPIで確認中...`); // ★追加ログ: 開始確認★
             const res = await fetch(`https://bot.sakurahp.f5.si/api/invites/${rawCode}`);
-            
-            console.log(`[API応答] Status: ${res.status}`); // ★追加ログ: HTTPステータス確認★
 
             if (!res.ok) {
-                // Firefoxでこのログが出た場合、CORSまたは外部ブロックの可能性が高い
-                console.error("⚠️ APIからHTTPエラー応答:", res.status, res.statusText);
+                console.error("APIからHTTPエラー応答:", res.status, res.statusText);
                 return null;
             }
 
             const data = await res.json();
             if (data.match === true && data.invite.guild?.id === allowedGuildId) {
-                console.log("✅ 招待コード検証OK: 有効なコードを確認しました。");
+                console.log("招待コード検証OK: 有効なコードを確認しました。");
                 return rawCode;
-            } else {
-                console.log("⚠️ 招待コードは無効か、許可されていないサーバーのものでした。データ:", data);
-                return null;
             }
+
+            console.log("招待コードは無効か、許可されていないサーバーのものでした。データ:", data);
+            return null;
         } catch (err) {
-            // Firefoxでここで止まる場合、セキュリティ機能によるブロックの可能性が濃厚
-            console.error("❌ 招待コード検証でネットワーク/ブロックエラー:", err); // ★エラー詳細を確認★
+            console.error("招待コード検証でネットワーク/ブロックエラー:", err);
             return null;
         }
     }
-    
-    const verifiedCode = await initInvite(); // 検証を実行
+
+    const verifiedCode = await initInvite();
     if (verifiedCode) {
-        finalCode = verifiedCode; // 有効なコードで更新
+        finalCode = verifiedCode;
     }
-    // 検証失敗時は finalCode はデフォルト値 "z7AmmNHvKR" のまま保持されます。
 
     // --- ボタン処理 ---
     buttons.forEach(btn => {
         btn.addEventListener("click", () => {
             console.log("ボタン押された。利用コード:", finalCode);
-
-            // 改善案: window.openは非同期ではないため、setTimeoutは短縮または削除を検討。
-            window.open(`https://discord.gg/${finalCode}`, "_blank");
+            window.open(`https://discord.gg/${finalCode}`, "_blank", "noopener");
         });
     });
 
     // --- お知らせ取得 ---
-try {
-    const box = document.getElementById("news_box");
-    if (box) box.textContent = "";
+    try {
+        const box = document.getElementById("news_box");
+        if (box) {
+            box.textContent = "";
+            box.setAttribute("aria-busy", "true");
+        }
 
-    const res = await fetch("https://api.kotoca.net/get?ch=announce");
-    if (!res.ok) throw new Error("Fetch失敗: " + res.status);
+        const res = await fetch("https://api.kotoca.net/get?ch=announce");
+        if (!res.ok) throw new Error("Fetch失敗: " + res.status);
 
-    const data = await res.json();
-    console.log("お知らせデータ取得:", data);
+        const data = await res.json();
+        console.log("お知らせデータ取得:", data);
 
-    if (box) {
-        data.forEach((entry, index) => {
-            const date = new Date(entry.createdAt).toLocaleString();
+        if (box) {
+            data.forEach((entry, index) => {
+                const date = new Date(entry.createdAt).toLocaleString();
+                const lines = entry.content.split("\n");
+                let titleLineIndex = lines.findIndex(line => line.startsWith("# "));
+                if (titleLineIndex === -1) titleLineIndex = 0;
 
-            const lines = entry.content.split('\n');
-            let titleLineIndex = lines.findIndex(line => line.startsWith('# '));
-            if (titleLineIndex === -1) titleLineIndex = 0;
+                const title = lines[titleLineIndex].replace(/^#\s*/, "");
+                const bodyLines = lines.slice(titleLineIndex + 1);
+                const body = bodyLines.join("\n");
+                const bodyId = `news-body-${index}`;
 
-            const title = lines[titleLineIndex].replace(/^#\s*/, '');
-            const bodyLines = lines.slice(titleLineIndex + 1);
-            const body = bodyLines.join('\n');
+                const article = document.createElement("article");
+                article.className = "news-item";
 
-            const pDate = document.createElement("p");
-            pDate.textContent = date;
+                const pDate = document.createElement("p");
+                pDate.textContent = date;
 
-            const h3 = document.createElement("h3");
-            h3.textContent = title;
-            h3.style.cursor = "pointer";
+                const heading = document.createElement("h3");
+                const toggle = document.createElement("button");
+                toggle.type = "button";
+                toggle.className = "news-toggle";
+                toggle.textContent = title;
+                toggle.setAttribute("aria-expanded", "false");
+                toggle.setAttribute("aria-controls", bodyId);
 
-            const divBody = document.createElement("div");
+                const divBody = document.createElement("div");
+                divBody.id = bodyId;
+                divBody.className = "news-body";
+                divBody.hidden = true;
 
-            // ★ Markdown → HTML
-            const html = marked.parse(body);
-            divBody.innerHTML = DOMPurify.sanitize(html);
+                const html = marked.parse(body);
+                divBody.innerHTML = DOMPurify.sanitize(html);
 
-            divBody.style.boxShadow = "none";
-            divBody.style.border = "none";
-            divBody.style.display = "none";
+                toggle.addEventListener("click", () => {
+                    const isOpen = toggle.getAttribute("aria-expanded") === "true";
+                    toggle.setAttribute("aria-expanded", String(!isOpen));
+                    divBody.hidden = isOpen;
+                });
 
-            h3.addEventListener("click", () => {
-                divBody.style.display =
-                    divBody.style.display === "none" ? "block" : "none";
+                heading.appendChild(toggle);
+                article.appendChild(pDate);
+                article.appendChild(heading);
+                article.appendChild(divBody);
+                box.appendChild(article);
+
+                if (index !== data.length - 1) {
+                    const hr = document.createElement("hr");
+                    box.appendChild(hr);
+                }
             });
-
-            box.appendChild(pDate);
-            box.appendChild(h3);
-            box.appendChild(divBody);
-
-            if (index !== data.length - 1) {
-                const hr = document.createElement("hr");
-                box.appendChild(hr);
-            }
-        });
+            box.setAttribute("aria-busy", "false");
+        }
+    } catch (err) {
+        console.error("お知らせ読み込みでエラー:", err);
+        const box = document.getElementById("news_box");
+        if (box) {
+            box.textContent = "お知らせの読み込み中にエラーが発生しました。";
+            box.setAttribute("aria-busy", "false");
+        }
     }
 
-} catch (err) {
-    console.error("お知らせ読み込みでエラー:", err);
-    const box = document.getElementById("news_box");
-    if (box) box.textContent = "お知らせの読み込み中にエラーが発生しました。";
-}
     // --- サーバー情報取得 ---
-    // 改善案: DOM要素の取得を一度にまとめて、エラー時の処理を共通化
     const domElements = {
         member: document.getElementById("member-count"),
         online: document.getElementById("online-count"),
@@ -137,62 +139,69 @@ try {
         const data = await res.json();
         console.log("サーバー情報取得:", data);
 
-        // データが存在すれば更新、なければ「取得不可」
         if (domElements.member) domElements.member.textContent = data.guild?.member ?? "取得不可";
         if (domElements.online) domElements.online.textContent = data.guild?.online ?? "取得不可";
         if (domElements.vc) domElements.vc.textContent = data.guild?.voice ?? "取得不可";
         if (domElements.timestamp) domElements.timestamp.textContent = data.timestamp ?? "エラーにより取得できませんでした";
-
     } catch (err) {
         console.error("サーバー情報読み込みでエラー:", err);
 
-        // エラー発生時は全て「エラー」表示
         if (domElements.member) domElements.member.textContent = errorText;
         if (domElements.online) domElements.online.textContent = errorText;
         if (domElements.vc) domElements.vc.textContent = errorText;
         if (domElements.timestamp) domElements.timestamp.textContent = errorText;
     }
-    
-async function loadEvents() {
-  const container = document.getElementById("events-api");
 
-  try {
-    const res = await fetch("https://bot.sakurahp.f5.si/api/events");
-    const data = await res.json();
+    async function loadEvents() {
+        const container = document.getElementById("events-api");
+        if (!container) return;
 
-    if (!data.events || data.events.length === 0) {
-      container.textContent = "イベントなし";
-      return;
+        try {
+            const res = await fetch("https://bot.sakurahp.f5.si/api/events");
+            if (!res.ok) throw new Error("Fetch失敗: " + res.status);
+
+            const data = await res.json();
+
+            if (!data.events || data.events.length === 0) {
+                container.textContent = "イベントなし";
+                return;
+            }
+
+            container.textContent = "";
+
+            data.events.forEach(event => {
+                const div = document.createElement("article");
+                div.className = "event";
+
+                const start = new Date(event.scheduled_start).toLocaleString();
+                const end = new Date(event.scheduled_end).toLocaleString();
+
+                const title = document.createElement("h3");
+                title.textContent = event.name || "イベント名未設定";
+
+                const description = document.createElement("p");
+                description.textContent = event.description || "説明はありません。";
+
+                const startText = document.createElement("p");
+                startText.textContent = `開始: ${start}`;
+
+                const endText = document.createElement("p");
+                endText.textContent = `終了: ${end}`;
+
+                const userCount = document.createElement("p");
+                userCount.textContent = `参加者: ${event.user_count ?? "不明"}`;
+
+                div.append(title, description, startText, endText, userCount);
+                container.appendChild(div);
+            });
+        } catch (err) {
+            container.textContent = "取得エラー";
+            console.error(err);
+        }
     }
 
-    container.innerHTML = "";
+    loadEvents();
 
-    data.events.forEach(event => {
-      const div = document.createElement("div");
-      div.className = "event";
-
-      const start = new Date(event.scheduled_start).toLocaleString();
-      const end = new Date(event.scheduled_end).toLocaleString();
-
-      div.innerHTML = `
-        <h3>${event.name}</h3>
-        <p>${event.description}</p>
-        <p>開始: ${start}</p>
-        <p>終了: ${end}</p>
-        <p>参加者: ${event.user_count}</p>
-      `;
-
-      container.appendChild(div);
-    });
-
-  } catch (err) {
-    container.textContent = "取得エラー";
-    console.error(err);
-  }
-}
-
-loadEvents();
-    
     // --- bot一覧取得 ---
     try {
         const res = await fetch("https://api.kotoca.net/get?ch=bots");
@@ -203,52 +212,40 @@ loadEvents();
 
         const ul = document.getElementById("bots_ul");
         const othersLi = document.getElementById("bots_others");
-        if (othersLi) othersLi.remove(); // 既存のプレースホルダーを削除
+        if (othersLi) othersLi.remove();
 
         if (ul) {
             data.forEach(entry => {
-                const lines = entry.content.split('\n');
+                const lines = entry.content.split("\n");
                 const botName = lines[0] || "名前不明";
-                const description = lines.slice(1).join('\n') || "";
+                const description = lines.slice(1).join("\n") || "";
 
                 const li = document.createElement("li");
-
-                // h3 と img をまとめる div
                 const topDiv = document.createElement("div");
-                topDiv.style.display = "grid";
-                topDiv.style.gridTemplateColumns = "50px 1fr";
-                topDiv.style.gridTemplateRows = "1fr";
+                topDiv.className = "bot-card-header";
 
-                // 添付画像がある場合のみ
                 if (entry.attach && entry.attach.length > 0) {
                     const img = document.createElement("img");
                     img.src = entry.attach[0];
-                    img.alt = botName;
-                    img.style.width = "50px";
-                    img.style.border = "solid #e099ae 4px";
+                    img.alt = `${botName}のアイコン`;
                     topDiv.appendChild(img);
                 }
 
                 const h3 = document.createElement("h3");
                 h3.textContent = botName;
-                h3.style.margin = "auto 0 auto 20px";
-                h3.style.display = "inline";
                 topDiv.appendChild(h3);
-
-                li.appendChild(topDiv);
 
                 const p = document.createElement("p");
                 p.textContent = description;
-                li.appendChild(p);
 
+                li.appendChild(topDiv);
+                li.appendChild(p);
                 ul.appendChild(li);
             });
         }
-
     } catch (err) {
         console.error("Bot一覧取得エラー:", err);
-        // エラー時のユーザーへのフィードバック（任意）
         const ul = document.getElementById("bots_ul");
-        if(ul) ul.innerHTML = `<li>Bot一覧の読み込み中にエラーが発生しました。</li>`;
+        if (ul) ul.innerHTML = `<li>Bot一覧の読み込み中にエラーが発生しました。</li>`;
     }
 });

--- a/others/style.css
+++ b/others/style.css
@@ -1,263 +1,366 @@
 /* fonts */
 @import url('https://fonts.googleapis.com/css2?family=WDXL+Lubrifont+JP+N&display=swap');
 
-* {
-  font-family: "WDXL Lubrifont JP N", sans-serif;
-  font-weight: 400;
-  font-style: normal;
-}
-
 :root {
     --brue: #6fb8c1;
+    --blue-shadow: #4f8792;
+    --pink: #e099ae;
+    --pink-soft: #f7e3e9;
+    --pink-shadow: #c57f94;
+    --surface: #fff;
+    --text: #1f1f1f;
+    --overlay-light: #00000033;
+    --overlay-medium: #00000055;
+    --overlay-strong: #000000aa;
+    --focus: #ffbf47;
 }
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+* {
+    font-family: "WDXL Lubrifont JP N", sans-serif;
+    font-weight: 400;
+    font-style: normal;
+}
+
 /* グローバル */
-html,body{
+html,
+body {
     margin: 0;
     scroll-behavior: smooth;
 }
 
-body{
+body {
     background-image: url(../assets/server_icon.png);
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
     background-attachment: fixed;
+    color: var(--text);
+    line-height: 1.65;
+    overflow-x: hidden;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+button,
+a,
+input,
+textarea {
+    font: inherit;
+}
+
+button,
+a {
+    touch-action: manipulation;
+}
+
+button {
+    cursor: pointer;
+}
+
+:focus-visible {
+    outline: 4px solid var(--focus);
+    outline-offset: 4px;
+}
+
+.skip-link {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 2000;
+    transform: translateY(calc(-100% - 2rem));
+    background: var(--surface);
+    color: #000;
+    padding: 0.75em 1em;
+    border: 4px solid var(--pink);
+    box-shadow: var(--pink-shadow) 5px 5px 0 0;
+    text-decoration: none;
+    transition: transform 0.15s ease;
+}
+
+.skip-link:focus-visible {
+    transform: translateY(0);
 }
 
 /* 参加ボタン共通デザイン */
-.join_button{
+.join_button {
     background-color: var(--brue);
     padding: 1em 2em;
     display: block;
+    width: fit-content;
+    max-width: min(92vw, 520px);
     margin: 10px auto;
-    font-size: 20px;
+    font-size: clamp(1rem, 3vw, 1.25rem);
     color: #fff;
     border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
-    transition: all 0.1s;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
+    transition: background-color 0.1s, color 0.1s, box-shadow 0.1s, transform 0.1s;
     z-index: 1000;
+    text-align: center;
 }
-.join_button:hover{
+
+.join_button:hover {
     background-color: #fff;
     box-shadow: var(--brue) 7px 7px 0 0;
     color: #000;
 }
-.join_button.clicked {
-    background-color: #f7e3e9;
+
+.join_button:active {
+    transform: translate(3px, 3px);
+    box-shadow: var(--blue-shadow) 4px 4px 0 0;
 }
+
+.join_button.clicked {
+    background-color: var(--pink-soft);
+}
+
 /* セクションタイトル系共通表示 */
-h2{
-    font-size: 2em;
+h2 {
+    font-size: clamp(1.6rem, 6vw, 2rem);
     display: block;
     width: fit-content;
+    max-width: calc(100vw - 2rem);
     margin: 0 auto;
     text-align: center;
     background-color: #e6dade;
     padding: 0.5em 1em;
-    border: #e099ae solid 5px;
-    box-shadow: #e0a3b6 7px 7px 0 0;
+    border: var(--pink) solid 5px;
+    box-shadow: var(--pink-shadow) 7px 7px 0 0;
     word-break: keep-all;
-}
-
-
-/* 改装中表示 */
-header{
-    position: fixed;
-    width: 100svw;
-    text-align: center;
-    background-color: #ffeaea;
-    pointer-events: none;
-}
-header p{
-    text-align: center;
-    color: #ff0000;
-    pointer-events: auto;
 }
 
 /* トップの要素 */
-#top{
-    background-color: #000000aa;
-    height: 90vh;
+#top {
+    background-color: var(--overlay-strong);
+    min-height: 90svh;
     margin: 0;
+    padding: 2rem 1rem;
     display: flex;
     flex-direction: column;
 }
-#top div{
+
+#top div {
     height: fit-content;
-    width: 90vw;
-    min-width: 320px;
+    width: min(90vw, 900px);
     margin: auto;
     text-align: center;
 }
-#top h1{
+
+#top h1 {
     color: #fff;
-    font-size: 4rem;
+    font-size: clamp(3rem, 12vw, 5rem);
     margin: 0;
     word-break: keep-all;
+    line-height: 1.15;
 }
-#top p{
-    color: #ddd;
-    font-size: 1.5rem;
+
+#top p {
+    color: #f2f2f2;
+    font-size: clamp(1.15rem, 4vw, 1.5rem);
 }
-#top a{
+
+#top a {
     text-align: center;
+    display: inline-flex;
+    justify-content: center;
+    width: fit-content;
+    margin: 0 auto;
+    border-radius: 999px;
 }
-#top img{
-    height: 45px;
+
+#top img {
     width: 80px;
     margin: 0 auto 20px auto;
     animation: float 1.5s ease-in-out infinite;
 }
+
 @keyframes float {
-    0%, 100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-5px); /* 上に5px移動 */
-    }
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-5px); }
 }
 
 /* おすすめポイント類 */
-#features{
-    background-color: #00000033;
-    margin: 0;
+#features,
+#news,
+#server-info,
+#events,
+#rules,
+#admin,
+#sns {
+    background-color: var(--overlay-light);
+}
+
+#features,
+#bots,
+#rules,
+#admin,
+#sns,
+#contact {
     padding: 5vh 0;
 }
-#features ul{
-    width: 90vw;
-    max-width: 500px;
+
+#features ul {
+    width: min(90vw, 500px);
     margin: 0 auto;
     padding: 0;
     counter-reset: feature-counter;
 }
-#features li{
+
+#features li {
     counter-increment: feature-counter;
-    height: fit-content;
     min-height: 20em;
     list-style-type: none;
-    background-color: #fff;
+    background-color: var(--surface);
     margin: 5vh 0;
     padding: 1em 2em;
     text-align: center;
-    
     border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
 }
+
 #features li::before {
     content: counter(feature-counter);
     font-size: 2em;
-    color: var(--brue);
+    color: #05687f;
 }
-#features li h3{
-    font-size: 1.9em;
+
+#features li h3 {
+    font-size: clamp(1.5rem, 5vw, 1.9rem);
 }
-#features li img{
+
+#features li img {
     width: 100%;
     margin: 0 0 2em 0;
 }
-#features p{
+
+#features p {
     font-size: 1.2em;
 }
-#features strong{
-    color: #037692;
+
+#features strong,
+#rules h3 {
+    color: #035d73;
 }
 
-#news{
+#news,
+#server-info,
+#events {
     padding: 0 0 5vh 0;
-    background-color: #00000033;
 }
-#news div{
-    width: 90vw;
-    max-width: 600px;
-    height: fit-content;
+
+#news_box,
+#api-data-area,
+#events-api,
+#rules ul,
+#contact form {
+    width: min(90vw, 600px);
+    background-color: var(--surface);
+    margin: 5vh auto;
+    padding: 1em;
+    border: var(--brue) 5px solid;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
+}
+
+#news_box {
     max-height: 600px;
-    overflow-y: scroll;
+    overflow-y: auto;
     scrollbar-width: thin;
-    background-color: #fff;
-    margin: 5vh auto;
-    padding: 1em;
-    text-align: center;
-    border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    text-align: left;
 }
 
-#server-info{
-    padding: 0 0 2vh 0;
-    background-color: #00000033;
-}
-#server-info div{
-    width: 90vw;
-    max-width: 600px;
-    background-color: #fff;
-    margin: 5vh auto;
-    padding: 1em;
+#news_box > .loading-message,
+#events-api > .loading-message,
+#api-data-area,
+#events-api {
     text-align: center;
-    border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
 }
-#server-info div span{
+
+.news-toggle {
+    display: block;
+    width: 100%;
+    margin: 0.5em 0;
+    padding: 0.75em 1em;
+    background: var(--pink-soft);
+    color: #000;
+    border: 4px solid var(--pink);
+    box-shadow: var(--pink-shadow) 4px 4px 0 0;
+    text-align: left;
+}
+
+.news-toggle[aria-expanded="true"] {
+    background: #fff;
+}
+
+.news-body {
+    padding: 0.5em 0.75em;
+}
+
+.news-body[hidden] {
+    display: none;
+}
+
+#server-info div span,
+#events div span {
     font-size: 2em;
-    color: #6c9aa5;
+    color: #4f8792;
 }
 
-#events{
-    padding: 0 0 2vh 0;
-    background-color: #00000033;
-}
-#events div{
-    width: 90vw;
-    max-width: 600px;
-    background-color: #fff;
-    margin: 5vh auto;
-    padding: 1em;
-    text-align: center;
-    border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
-}
-#events div span{
-    font-size: 2em;
-    color: #6c9aa5;
+.event {
+    border-top: 2px solid #d8edf0;
+    padding-top: 1em;
+    margin-top: 1em;
 }
 
-#bots{
-    padding: 5vh 0 5vh 0;
-    background-color: #00000055;
+#bots {
+    background-color: var(--overlay-medium);
 }
-#bots p{
+
+#bots p {
     text-align: center;
     color: #fff;
     font-size: 1.5em;
 }
-#bots ul{
-    padding: 0;
+
+#bots ul {
+    padding: 0 0.5rem 0.75rem 0;
     margin: 0 5vw;
     list-style: none;
     display: grid;
     gap: 1em;
-    overflow-x: scroll;
-    scrollbar-width: none;
-
-    display: grid;
-    grid-template-rows: repeat(2, auto); /* 縦に2行 */
-    grid-auto-flow: column; /* 横方向にアイテムを配置 */
+    overflow-x: auto;
+    scrollbar-width: thin;
+    grid-template-rows: repeat(2, auto);
+    grid-auto-flow: column;
 }
-#bots li{
+
+#bots li {
     display: block;
-    width: 400px;
-    background-color: #fff;
+    width: min(400px, 80vw);
+    background-color: var(--surface);
     padding: 1em 2em;
     border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
 }
-#bots li h3{
+
+#bots li h3 {
     font-size: 1.5em;
 }
-#bots li p{
+
+#bots li p {
     color: #000;
     font-size: 1em;
     text-align: left;
 }
-#bots li a{
+
+#bots li a {
     display: block;
     padding: 1em;
     margin: 1em 0;
@@ -265,138 +368,220 @@ header p{
     color: #fff;
     text-decoration: none;
     border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
 }
-#bots li a:hover{
+
+#bots li a:hover {
     background-color: #fff;
     color: #000;
 }
-.bots_sakurabot{
+
+.bots_sakurabot {
     grid-row: 1 / 3;
     grid-column: 1 / 2;
 }
 
-#rules{
-    padding: 5vh 0 5vh 0;
-    background-color: #00000033;
-}
-#rules ul{
-    padding: 1em 2em;
-    margin: 5vh auto;
-    width: 90vw;
-    max-width: 600px;
-    background-color: #fff;
-    list-style: none;
-    border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
-    height: 500px;
-    overflow-y: scroll;
-}
-#rules h3{
-    color: #037692;
-}
-#rules strong{
-    font-size: 1.2em;
+#bots_others {
+    grid-row: 1 / 2;
+    grid-column: 2 / 3;
 }
 
-#admin{
-    padding: 5vh 0 5vh 0;
-    background-color: #00000033;
+.bot-card-header {
+    display: grid;
+    grid-template-columns: 50px 1fr;
+    align-items: center;
+    gap: 1em;
 }
-#admin ul{
+
+.bot-card-header img {
+    width: 50px;
+    border: solid var(--pink) 4px;
+}
+
+.bot-card-header h3 {
+    margin: 0;
+}
+
+.section-lead {
+    width: min(90vw, 600px);
+    margin: 2rem auto 0;
+    padding: 1em 1.25em;
+    background: var(--surface);
+    border: var(--pink) solid 5px;
+    box-shadow: var(--pink-shadow) 7px 7px 0 0;
+}
+
+#rules ul {
+    list-style: none;
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+#rules strong {
+    font-size: 1.1em;
+}
+
+#admin ul {
     list-style: none;
     margin: 1em 2em;
-    padding: 0;
+    padding: 0 0.5rem 0.75rem 0;
     display: flex;
     gap: 2em;
-    overflow-x: scroll;
-    scrollbar-width: none;
+    overflow-x: auto;
+    scrollbar-width: thin;
 }
-#admin li{
-    background-color: #fff;
+
+#admin li {
+    background-color: var(--surface);
     padding: 1em 2em;
     border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    box-shadow: var(--blue-shadow) 7px 7px 0 0;
     width: calc(100px + 12em);
     min-width: calc(100px + 12em);
 }
-#admin ul li div{
+
+#admin ul li div {
     display: grid;
     grid-template-columns: 130px 1fr;
 }
-#admin img{
+
+#admin img {
     height: 100px;
-    grid-column: 1 /2;
+    width: 100px;
+    object-fit: cover;
+    grid-column: 1 / 2;
     grid-row: 1 / 3;
-    
-    border: #e099ae 5px solid;
-    box-shadow: #e0a3b6 5px 5px 0 0;
+    border: var(--pink) 5px solid;
+    box-shadow: var(--pink-shadow) 5px 5px 0 0;
 }
-#admin div.admin_tags{
+
+#admin div.admin_tags {
     display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
 }
-#admin small{
+
+#admin small {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
-    background-color: #f7e3e9;
-    padding: 0.5em 1em;
+    background-color: var(--pink-soft);
+    padding: 0.35em 0.75em;
     margin: 1.5em 0.5em 0 0;
 }
-#admin h3{
+
+#admin h3 {
     grid-column: 2 / 3;
     grid-row: 2 / 3;
     font-size: 1.5em;
     margin: 0.5em 0;
 }
 
-#sns{
-    padding: 5vh 0 5vh 0;
-    background-color: #00000033;
-}
-#sns ul{
+#sns ul {
     padding: 0;
     margin: 1em 2em;
     list-style: none;
     max-height: 1000px;
 }
-#sns li.sns_x{
-    width: 90vw;
-    max-width: 700px;
+
+#sns li.sns_x {
+    width: min(90vw, 700px);
     height: 600px;
-    overflow-y: scroll;
+    overflow-y: auto;
     scrollbar-width: thin;
     margin: 0 auto;
 }
 
-#contact{
-    padding: 5vh 0 5vh 0;
-}
-#contact form{
-    background-color: #fff;
-    width: 90vw;
-    padding: 1em 2em;
-    max-width: 600px;
+#contact form {
     margin: 2em auto;
-    border: var(--brue) 5px solid;
-    box-shadow: #6c9aa5 7px 7px 0 0;
+    padding: 1em 2em;
     display: flex;
     flex-direction: column;
-}
-#contact input,textarea{
-    border: #e099ae 5px solid;
-    box-shadow: #e0a3b6 5px 5px 0 0;
-    width: 90%;
-    margin: 1em auto;
-    padding: 1em;
-}
-#contact button{
-    background-color: #e099ae;
-    color: #fff;
-    border: #e099ae 5px solid;
-    box-shadow: #e0a3b6 5px 5px 0 0;
-    padding: 1em auto;
+    gap: 0.75rem;
 }
 
-footer p{
+#contact label {
+    font-size: 1.1em;
+}
+
+#contact input,
+#contact textarea {
+    border: var(--pink) 5px solid;
+    box-shadow: var(--pink-shadow) 5px 5px 0 0;
+    width: 100%;
+    margin: 0 0 1em 0;
+    padding: 1em;
+    background: #fff;
+    color: #000;
+}
+
+#contact textarea {
+    min-height: 10rem;
+    resize: vertical;
+}
+
+#contact button {
+    background-color: var(--pink);
+    color: #fff;
+    border: var(--pink) 5px solid;
+    box-shadow: var(--pink-shadow) 5px 5px 0 0;
+    padding: 1em 2em;
+    min-height: 48px;
+}
+
+#contact button:hover {
+    background: #fff;
+    color: #000;
+}
+
+footer {
+    background: #ffffffdd;
+    padding: 1.5rem 1rem;
+}
+
+footer p {
     text-align: center;
+    margin: 0.35em 0;
+}
+
+@media (max-width: 640px) {
+    body {
+        background-attachment: scroll;
+    }
+
+    #features li,
+    #bots li,
+    #admin li,
+    #contact form {
+        padding: 1em;
+    }
+
+    #admin li {
+        width: min(82vw, 320px);
+        min-width: min(82vw, 320px);
+    }
+
+    #admin ul li div {
+        grid-template-columns: 100px 1fr;
+        gap: 0.5rem;
+    }
+
+    #admin img {
+        width: 82px;
+        height: 82px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html,
+    body {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }


### PR DESCRIPTION
### Motivation
- Preserve the original visual design while improving keyboard and screen-reader accessibility for core landing page interactions and dynamic content.
- Fix HTML structure issues and UI layout problems that caused content/semantic instability on some viewports and assistive technologies.
- Make client-side rendering of news, events, and bot lists safer and more robust to avoid layout shift and accidental HTML injection.

### Description
- Updated `index.html` to add a skip link (`.skip-link`), set explicit `type="button"` on non-form buttons, add `aria-live`/`aria-busy` regions for dynamic areas, improve form labels/autocomplete/`aria-required`, add `rel="noopener"` to external links, and improve decorative image semantics (`alt`/`aria-hidden`).
- Reworked `others/script.js` to validate invites robustly, use `window.open(..., "noopener")`, render news/events/bots with DOM APIs instead of raw `innerHTML`, add accessible toggles with `aria-expanded`/`aria-controls`, and provide better error/busy state handling for dynamic content.
- Rewrote `others/style.css` to introduce consistent `box-sizing`, CSS variables, `:focus-visible` outlines, responsive sizing, reduced-motion handling, skip-link styling, safer widths for buttons/cards, and moved inline styles into classes to prevent layout breakage.
- Removed fragile markup patterns (e.g. `ul > p`) and adjusted wording/placeholder text to be more consistent and accessible across sections.

### Testing
- Ran `node --check others/script.js` which completed without syntax errors.
- Executed a static accessibility check using a Python `HTMLParser` script that verified `button` `type` attributes, `img` `alt` attributes, and that form inputs have corresponding labels; the check passed.
- Served the site locally with `python3 -m http.server` and verified `index.html` responded via `curl -I` successfully.
- Ran `git diff --check` to ensure no whitespace/format issues; no problems detected, and note that `npx playwright --version` was attempted for visual tests but failed due to `npm` registry `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05446f91008326bf279c8402310631)